### PR TITLE
Allowing Permission Methods in SDK

### DIFF
--- a/packages/client/src/MWPClient.ts
+++ b/packages/client/src/MWPClient.ts
@@ -150,6 +150,7 @@ export class MWPClient {
       case 'wallet_watchAsset':
       case 'wallet_sendCalls':
       case 'wallet_showCallsStatus':
+      case 'wallet_grantPermissions':
         return this.sendRequestToPopup(request);
       default:
         if (!this.chain.rpcUrl) throw standardErrors.rpc.internal('No RPC URL set for chain');


### PR DESCRIPTION
### _Summary_

3 new permission methods were introduced, they are

wallet_grantPermissions
wallet_prepareCalls
wallet_sendPreparedCalls
Allowing them in MWPClient.

### _How did you test your changes?_

Unit Tests added
