### PR TITLE
New Config AppCustomScheme - To enable less disruptive communication channel 

### DIFF
--- a/packages/client/src/MWPClient.ts
+++ b/packages/client/src/MWPClient.ts
@@ -49,6 +49,9 @@ export class MWPClient {
       ...metadata,
       appName: metadata.appName || 'Dapp',
       appDeeplinkUrl: appendMWPResponsePath(metadata.appDeeplinkUrl),
+      appCustomScheme: metadata.appCustomScheme
+        ? appendMWPResponsePath(metadata.appCustomScheme)
+        : undefined,
     };
 
     this.wallet = wallet;
@@ -90,7 +93,10 @@ export class MWPClient {
     const handshakeMessage = await this.createRequestMessage({
       handshake: {
         method: 'eth_requestAccounts',
-        params: this.metadata,
+        params: {
+          appName: this.metadata.appName,
+          appLogoUrl: this.metadata.appLogoUrl,
+        },
       },
     });
     const response: RPCResponseMessage = await Communicator.postRequestToWallet(
@@ -233,6 +239,7 @@ export class MWPClient {
       sdkVersion: LIB_VERSION,
       timestamp: new Date(),
       callbackUrl: this.metadata.appDeeplinkUrl,
+      customScheme: this.metadata.appCustomScheme,
     };
   }
 

--- a/packages/client/src/components/communicator/postRequestToWallet.test.ts
+++ b/packages/client/src/components/communicator/postRequestToWallet.test.ts
@@ -16,9 +16,10 @@ describe('postRequestToWallet', () => {
     content: {
       handshake: {
         method: 'eth_requestAccounts',
-        params: { appName: 'test', appChainIds: [1], appDeeplinkUrl: 'https://example.com' },
+        params: { appName: 'test' },
       },
     },
+    callbackUrl: 'https://example.com',
     sender: 'Sender',
     timestamp: new Date(),
   };

--- a/packages/client/src/components/communicator/webBased/encoding.test.ts
+++ b/packages/client/src/components/communicator/webBased/encoding.test.ts
@@ -14,7 +14,6 @@ describe('encoding', () => {
           method: 'eth_requestAccounts',
           params: {
             appName: 'My App',
-            appDeeplinkUrl: 'https://myapp.example.com',
           },
         },
       },
@@ -23,7 +22,7 @@ describe('encoding', () => {
     const result = encodeRequestURLParams(request);
 
     expect(result).toEqual(
-      'id=%221%22&sender=%22sender%22&sdkVersion=%221.0.0%22&callbackUrl=%22https%3A%2F%2Fcallback.example.com%22&timestamp=%222021-01-01T00%3A00%3A00.000Z%22&content=%7B%22handshake%22%3A%7B%22method%22%3A%22eth_requestAccounts%22%2C%22params%22%3A%7B%22appName%22%3A%22My+App%22%2C%22appDeeplinkUrl%22%3A%22https%3A%2F%2Fmyapp.example.com%22%7D%7D%7D'
+      'id=%221%22&sender=%22sender%22&sdkVersion=%221.0.0%22&callbackUrl=%22https%3A%2F%2Fcallback.example.com%22&timestamp=%222021-01-01T00%3A00%3A00.000Z%22&content=%7B%22handshake%22%3A%7B%22method%22%3A%22eth_requestAccounts%22%2C%22params%22%3A%7B%22appName%22%3A%22My+App%22%7D%7D%7D'
     );
   });
 
@@ -33,6 +32,29 @@ describe('encoding', () => {
       sender: 'sender',
       sdkVersion: '1.0.0',
       callbackUrl: 'https://callback.example.com',
+      timestamp: new Date('2021-01-01T00:00:00Z'),
+      content: {
+        encrypted: {
+          iv: new Uint8Array([1, 2, 3]),
+          cipherText: new Uint8Array([4, 5, 6]),
+        },
+      },
+    };
+
+    const result = encodeRequestURLParams(request);
+
+    expect(result).toEqual(
+      'id=%221%22&sender=%22sender%22&sdkVersion=%221.0.0%22&callbackUrl=%22https%3A%2F%2Fcallback.example.com%22&timestamp=%222021-01-01T00%3A00%3A00.000Z%22&content=%7B%22encrypted%22%3A%7B%22iv%22%3A%22010203%22%2C%22cipherText%22%3A%22040506%22%7D%7D'
+    );
+  });
+
+  it('should emit falsy param when encoding', () => {
+    const request: RPCRequestMessage = {
+      id: '1' as MessageID,
+      sender: 'sender',
+      sdkVersion: '1.0.0',
+      callbackUrl: 'https://callback.example.com',
+      customScheme: undefined, // falsy
       timestamp: new Date('2021-01-01T00:00:00Z'),
       content: {
         encrypted: {

--- a/packages/client/src/components/communicator/webBased/encoding.ts
+++ b/packages/client/src/components/communicator/webBased/encoding.ts
@@ -48,13 +48,14 @@ export function decodeResponseURLParams(params: URLSearchParams): RPCResponseMes
 export function encodeRequestURLParams(request: RPCRequestMessage) {
   const urlParams = new URLSearchParams();
   const appendParam = (key: string, value: unknown) => {
-    urlParams.append(key, JSON.stringify(value));
+    if (value) urlParams.append(key, JSON.stringify(value));
   };
 
   appendParam('id', request.id);
   appendParam('sender', request.sender);
   appendParam('sdkVersion', request.sdkVersion);
   appendParam('callbackUrl', request.callbackUrl);
+  appendParam('customScheme', request.customScheme);
   appendParam('timestamp', request.timestamp);
 
   if ('handshake' in request.content) {

--- a/packages/client/src/core/message/RPCMessage.ts
+++ b/packages/client/src/core/message/RPCMessage.ts
@@ -16,7 +16,8 @@ export type EncryptedData = {
 
 export interface RPCRequestMessage extends RPCMessage {
   sdkVersion: string;
-  callbackUrl?: string;
+  callbackUrl: string;
+  customScheme?: string;
   content:
     | {
         handshake: RequestAccountsAction;
@@ -39,5 +40,5 @@ export interface RPCResponseMessage extends RPCMessage {
 
 type RequestAccountsAction = {
   method: 'eth_requestAccounts';
-  params: AppMetadata;
+  params: Pick<AppMetadata, 'appName' | 'appLogoUrl'>;
 };

--- a/packages/client/src/core/provider/interface.ts
+++ b/packages/client/src/core/provider/interface.ts
@@ -34,23 +34,38 @@ export interface ProviderInterface extends ProviderEventEmitter {
 export type ProviderEventCallback = ProviderInterface['emit'];
 
 export interface AppMetadata {
-  /** Application name */
+  /**
+   * @param appName
+   * @type string
+   * @description Application name
+   */
   appName: string;
-  /** Application logo image URL; favicon is used if unspecified */
-  // TODO: make this required
+  /**
+   * @param appLogoUrl
+   * @type {string}
+   * @description Application logo image URL
+   */
   appLogoUrl?: string;
-  /** Array of chainIds your dapp supports */
+  /**
+   * @param appChainIds
+   * @type {number[]}
+   * @description Array of chainIds in number your dapp supports
+   */
   appChainIds?: number[];
-  /** Mobile Only: Universal Link url or App Link url */
+  /**
+   * @param appDeeplinkUrl
+   * @type string
+   * @note HTTPS URL is required for production
+   * @description Universal Link url on iOS or App Link url on Android to establish app's identity
+   * @example 'https://example.com'
+   */
   appDeeplinkUrl: string;
-}
-
-export interface Preference {
-  options: 'all' | 'smartWalletOnly' | 'eoaOnly';
-  keysUrl?: string;
-}
-
-export interface ConstructorOptions {
-  metadata: AppMetadata;
-  preference: Preference;
+  /**
+   * @param appCustomScheme
+   * @type {string}
+   * @note Optional, but will be required in next minor version
+   * @description Custom URL scheme used for establishing less disruptive communication channel with wallet
+   * @example 'myapp://'
+   */
+  appCustomScheme?: string;
 }


### PR DESCRIPTION
### _Summary_

Added a new config param for SDK, which can now be used to pass response in a less disruptive way, no go-back screen needed.

### _How did you test your changes?_

Unit Test + Manually tested
