### PR TITLE
fix: dismissBrowser is promise in Expo SDK52

### DIFF
--- a/packages/client/src/components/communicator/webBased/Communicator.ts
+++ b/packages/client/src/components/communicator/webBased/Communicator.ts
@@ -43,9 +43,18 @@ class WebBasedWalletCommunicatorClass {
 
     const handler = this.responseHandlers.get(response.requestId);
     if (handler) {
-      handler(response);
-      this.responseHandlers.delete(response.requestId);
-      WebBrowser.dismissBrowser();
+      const dismissResult = WebBrowser.dismissBrowser();
+      if (dismissResult && typeof dismissResult.then === 'function') {
+        // If dismissBrowser returns a promise, handle it asynchronously
+        dismissResult.then(() => {
+            handler(response);
+            this.responseHandlers.delete(response.requestId);
+        });
+      } else {
+        // If dismissBrowser is undefined or doesn't return a promise (Android case), handle synchronously
+        handler(response);
+        this.responseHandlers.delete(response.requestId);
+      }
       return true;
     }
     return false;


### PR DESCRIPTION
### _Summary_
We introduced a change in `expo-web-browser`, [which was merged](https://github.com/expo/expo/pull/31210) recently and will soon be released with SDK 52. This update makes `dismissBrowser` a promise, which helps [prevent a few bugs](https://github.com/expo/expo/pull/31210), particularly some issues we encountered with this SDK.

<!--
  What changed? Link to relevant issues.
-->

The function is iOS-only, and no Platform checks were added. Since `.then()` can't be called on `undefined`, I had to create a workaround to support iOS's new async syntax, with a fallback to synchronous calls for all other platforms.

### _How did you test your changes?_

Tested on both device and simulator.

<!--
  Verify changes. Include relevant screenshots/videos
-->